### PR TITLE
trivial patch to enable non-interactive generation

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -11,6 +11,10 @@ var extend = require('deep-extend')
 module.exports = yeoman.generators.Base.extend({
 
   prompting: function () {
+    if (this.options.name) {
+      this.projectName = this.options.name
+      return
+    }
     var done = this.async();
 
     this.log(yosay(


### PR DESCRIPTION
e.g. allows us to pass name option from fuge : `env.run('seneca-redis', {name: 'my-service'}, cb)` and means we keep our output clean

at the same time, the generator can still be used standalone
